### PR TITLE
Reuse if x-request-header already exists in the http header.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/gravityblast/xrequestid
-
-go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gravityblast/xrequestid
+
+go 1.16

--- a/xrequestid_middleware.go
+++ b/xrequestid_middleware.go
@@ -56,10 +56,14 @@ func New(n int) *XRequestID {
 }
 
 func (m *XRequestID) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	id, err := m.Generate(m.Size)
+  requestID := r.Header.Get(m.HeaderKey)
+	err := error(nil)
+  if requestID == "" {
+    requestID, err = m.Generate(m.Size)
+  }
 	if err == nil {
-		r.Header.Set(m.HeaderKey, id)
-		rw.Header().Set(m.HeaderKey, id)
+		r.Header.Set(m.HeaderKey, requestID)
+		rw.Header().Set(m.HeaderKey, requestID)
 	}
 
 	next(rw, r)

--- a/xrequestid_middleware_test.go
+++ b/xrequestid_middleware_test.go
@@ -6,12 +6,29 @@ import (
 	"testing"
 )
 
-func TestXRequestID(t *testing.T) {
+func TestNonExistXRequestIDInHeader(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
 
 	middleware := New(16)
 	middleware.Generate = func(n int) (string, error) { return "test-id", nil }
+	middleware.ServeHTTP(recorder, req, func(w http.ResponseWriter, r *http.Request) {})
+
+	if id := req.Header.Get("X-Request-ID"); id != "test-id" {
+		t.Fatalf("Expected request X-Request-Id to be `test-id`, got `%v`", id)
+	}
+
+	if responseID := recorder.HeaderMap.Get("X-Request-ID"); responseID != "test-id" {
+		t.Fatalf("Expected response X-Request-Id to be `test-id`, got `%v`", responseID)
+	}
+}
+
+func TestExistXRequestIDInHeader(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "test-id")
+
+	middleware := New(16)
 	middleware.ServeHTTP(recorder, req, func(w http.ResponseWriter, r *http.Request) {})
 
 	if id := req.Header.Get("X-Request-ID"); id != "test-id" {


### PR DESCRIPTION
fixes https://github.com/gravityblast/xrequestid/issues/3
